### PR TITLE
fix: Bus realtime query not working without route params

### DIFF
--- a/src/bus/query.py
+++ b/src/bus/query.py
@@ -343,6 +343,8 @@ async def resolve_bus(
                                     route_id is not None and x.route.id_ == route_id
                                 ) or (
                                     routes is not None and x.route.id_ in routes
+                                ) or (
+                                    route_id is None and routes is None
                                 ),
                                 stop.routes,
                             ),


### PR DESCRIPTION
## Changes
- 노선버스 데이터를 조회할 때 노선 쿼리를 포함하지 않으면 아무 데이터가 보내지지 않는 문제 수정