### PR TITLE
fix: Include missing property in shuttle route list API

### DIFF
--- a/src/shuttle/router.py
+++ b/src/shuttle/router.py
@@ -246,6 +246,8 @@ async def get_route_list(
         "tag": x.tag,
         "korean": x.korean,
         "english": x.english,
+        "start": x.start_stop_id,
+        "end": x.end_stop_id,
     }
     return {"data": map(mapping_func, data)}
 

--- a/src/shuttle/schemas.py
+++ b/src/shuttle/schemas.py
@@ -204,15 +204,6 @@ class ShuttlePeriodListResponse(BaseModel):
     data: Annotated[list["ShuttlePeriodItemResponse"], Field(alias="data")]
 
 
-class ShuttleRouteListItemResponse(BaseModel):
-    name: Annotated[str, Field(max_length=15, alias="name")]
-    tag: Annotated[str, Field(max_length=10, alias="tag")]
-
-
-class ShuttleRouteListResponse(BaseModel):
-    data: Annotated[list["ShuttleRouteListItemResponse"], Field(alias="data")]
-
-
 class ShuttleRouteDetailResponse(BaseModel):
     name: Annotated[str, Field(max_length=15, alias="name")]
     tag: Annotated[str, Field(max_length=10, alias="tag")]
@@ -220,6 +211,10 @@ class ShuttleRouteDetailResponse(BaseModel):
     route_description_english: Annotated[str, Field(max_length=100, alias="english")]
     start_stop_id: Annotated[str, Field(alias="start", max_length=15)]
     end_stop_id: Annotated[str, Field(alias="end", max_length=15)]
+
+
+class ShuttleRouteListResponse(BaseModel):
+    data: Annotated[list["ShuttleRouteDetailResponse"], Field(alias="data")]
 
 
 class ShuttleRouteStopResponse(BaseModel):

--- a/tests/test_shuttle_routes.py
+++ b/tests/test_shuttle_routes.py
@@ -501,6 +501,10 @@ async def test_get_shuttle_route(
     for route in response_json.get("data"):
         assert route.get("name") is not None
         assert route.get("tag") is not None
+        assert route.get("korean") is not None
+        assert route.get("english") is not None
+        assert route.get("start") is not None
+        assert route.get("end") is not None
 
 
 @pytest.mark.asyncio
@@ -521,6 +525,10 @@ async def test_get_shuttle_route_filter_name(
     for route in response_json.get("data"):
         assert route.get("name") == "test_route1"
         assert route.get("tag") is not None
+        assert route.get("korean") is not None
+        assert route.get("english") is not None
+        assert route.get("start") is not None
+        assert route.get("end") is not None
 
 
 @pytest.mark.asyncio
@@ -541,6 +549,10 @@ async def test_get_shuttle_route_filter_tag(
     for route in response_json.get("data"):
         assert route.get("name") is not None
         assert route.get("tag") == "test_tag"
+        assert route.get("korean") is not None
+        assert route.get("english") is not None
+        assert route.get("start") is not None
+        assert route.get("end") is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Changes
- 셔틀 노선 목록 API에서 한국어/영어 설명 및 시점/종점 정류장 정보가 누락되어 있던 문제 수정