### PR TITLE
fix: Change timedelta type to seconds to show as int type

### DIFF
--- a/src/shuttle/router.py
+++ b/src/shuttle/router.py
@@ -410,7 +410,7 @@ async def get_route_stop_list(
         "route": x.route_name,
         "stop": x.stop_name,
         "sequence": x.sequence,
-        "cumulativeTime": timedelta_to_str(x.cumulative_time),
+        "cumulativeTime": x.cumulative_time.total_seconds(),
     }
     return {"data": map(mapping_func, data)}
 
@@ -433,7 +433,7 @@ async def create_route_stop(
         "route": data.route_name,
         "stop": data.stop_name,
         "sequence": data.sequence,
-        "cumulativeTime": timedelta_to_str(data.cumulative_time),
+        "cumulativeTime": data.cumulative_time.total_seconds(),
     }
 
 
@@ -453,7 +453,7 @@ async def get_route_stop(
         "route": data.route_name,
         "stop": data.stop_name,
         "sequence": data.sequence,
-        "cumulativeTime": timedelta_to_str(data.cumulative_time),
+        "cumulativeTime": data.cumulative_time.total_seconds(),
     }
 
 
@@ -477,7 +477,7 @@ async def update_route_stop(
         "route": data.route_name,
         "stop": data.stop_name,
         "sequence": data.sequence,
-        "cumulativeTime": timedelta_to_str(data.cumulative_time),
+        "cumulativeTime": data.cumulative_time.total_seconds(),
     }
 
 

--- a/src/shuttle/router.py
+++ b/src/shuttle/router.py
@@ -60,7 +60,7 @@ from shuttle.schemas import (
     UpdateShuttleRouteStopRequest,
 )
 from user.jwt import parse_jwt_user_data
-from utils import timedelta_to_str, timestamp_tz_to_datetime
+from utils import timestamp_tz_to_datetime
 
 router = APIRouter()
 

--- a/src/shuttle/schemas.py
+++ b/src/shuttle/schemas.py
@@ -122,30 +122,27 @@ class UpdateShuttleStopRequest(BaseModel):
 class CreateShuttleRouteStopRequest(BaseModel):
     stop_name: Annotated[str, Field(max_length=15, alias="stop")]
     sequence: Annotated[int, Field(alias="sequence", ge=0)]
-    cumulative_time: Annotated[datetime.timedelta, Field(alias="cumulativeTime")]
+    cumulative_time: Annotated[int, Field(alias="cumulativeTime")]
 
     class Config:
         json_schema_extra = {
             "example": {
                 "stop": "shuttlecock_o",
                 "sequence": 1,
-                "cumulativeTime": "00:00:00",
+                "cumulativeTime": 300,
             },
         }
 
 
 class UpdateShuttleRouteStopRequest(BaseModel):
-    sequence: Annotated[Optional[int], Field(alias="sequence", ge=1)]
-    cumulative_time: Annotated[
-        Optional[datetime.timedelta],
-        Field(alias="cumulativeTime"),
-    ]
+    sequence: Annotated[Optional[int], Field(alias="sequence", ge=0)]
+    cumulative_time: Annotated[Optional[int], Field(alias="cumulativeTime")]
 
     class Config:
         json_schema_extra = {
             "example": {
                 "sequence": 1,
-                "cumulativeTime": "00:00:00",
+                "cumulativeTime": 300,
             },
         }
 
@@ -237,7 +234,7 @@ class ShuttleRouteStopItemResponse(BaseModel):
     route_name: Annotated[str, Field(max_length=15, alias="route")]
     stop_name: Annotated[str, Field(max_length=15, alias="stop")]
     sequence: Annotated[int, Field(alias="sequence", ge=0)]
-    cumulative_time: Annotated[str, Field(alias="cumulativeTime")]
+    cumulative_time: Annotated[int, Field(alias="cumulativeTime")]
 
 
 class ShuttleRouteStopListResponse(BaseModel):

--- a/src/shuttle/service.py
+++ b/src/shuttle/service.py
@@ -24,7 +24,7 @@ from shuttle.schemas import (
     UpdateShuttleTimetableRequest,
     UpdateShuttleStopRequest,
 )
-from utils import KST
+from utils import KST, second_to_timedelta
 
 
 async def list_holiday() -> list[ShuttleHoliday]:
@@ -342,7 +342,7 @@ async def create_route_stop(
                 "route_name": route_name,
                 "stop_name": new_route_stop.stop_name,
                 "stop_order": new_route_stop.sequence,
-                "cumulative_time": new_route_stop.cumulative_time,
+                "cumulative_time": second_to_timedelta(new_route_stop.cumulative_time),
             },
         )
     )
@@ -363,7 +363,7 @@ async def update_route_stop(
     if new_route_stop.sequence:
         payload["sequence"] = new_route_stop.sequence
     if new_route_stop.cumulative_time:
-        payload["cumulative_time"] = new_route_stop.cumulative_time
+        payload["cumulative_time"] = second_to_timedelta(new_route_stop.cumulative_time)
     update_query = (
         update(ShuttleRouteStop)
         .where(

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,6 +19,10 @@ def timedelta_to_str(td: datetime.timedelta) -> str:
     return f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}"
 
 
+def second_to_timedelta(seconds: int) -> datetime.timedelta:
+    return datetime.timedelta(seconds=seconds)
+
+
 def remove_timezone(dt: datetime.time) -> datetime.time:
     return dt.replace(tzinfo=None)
 

--- a/tests/test_shuttle_routes.py
+++ b/tests/test_shuttle_routes.py
@@ -1106,7 +1106,7 @@ async def test_create_shuttle_route_stop(
         json={
             "stop": "test_stop3",
             "sequence": 3,
-            "cumulativeTime": "00:10:00",
+            "cumulativeTime": 600,
         },
     )
     assert response.status_code == 201
@@ -1114,7 +1114,7 @@ async def test_create_shuttle_route_stop(
     assert response_json.get("route") == "test_route1"
     assert response_json.get("stop") == "test_stop3"
     assert response_json.get("sequence") == 3
-    assert response_json.get("cumulativeTime") == "00:10:00"
+    assert response_json.get("cumulativeTime") == 600
     check_statement = select(ShuttleRouteStop).where(
         ShuttleRouteStop.route_name == "test_route1",
         ShuttleRouteStop.stop_name == "test_stop3",
@@ -1143,7 +1143,7 @@ async def test_create_shuttle_route_stop_duplicate(
         json={
             "stop": "test_stop1",
             "sequence": 3,
-            "cumulativeTime": "00:10:00",
+            "cumulativeTime": 600,
         },
     )
     assert response.status_code == 409
@@ -1165,7 +1165,7 @@ async def test_create_shuttle_route_stop_route_not_found(
         json={
             "stop": "test_stop1",
             "sequence": 3,
-            "cumulativeTime": "00:10:00",
+            "cumulativeTime": 600,
         },
     )
     assert response.status_code == 404
@@ -1196,7 +1196,7 @@ async def test_create_shuttle_route_stop_internal_server_error(
         json={
             "stop": "test_stop3",
             "sequence": 3,
-            "cumulativeTime": "00:10:00",
+            "cumulativeTime": 600,
         },
     )
     assert response.status_code == 500
@@ -1254,7 +1254,7 @@ async def test_update_shuttle_route_stop_item(
         headers={"Authorization": f"Bearer {access_token}"},
         json={
             "sequence": 2,
-            "cumulativeTime": "00:10:00",
+            "cumulativeTime": -300,
         },
     )
     assert response.status_code == 200

--- a/tests/test_shuttle_routes.py
+++ b/tests/test_shuttle_routes.py
@@ -1278,7 +1278,7 @@ async def test_update_shuttle_route_stop_item_not_found(
         headers={"Authorization": f"Bearer {access_token}"},
         json={
             "sequence": 2,
-            "cumulativeTime": "00:10:00",
+            "cumulativeTime": -300,
         },
     )
     assert response.status_code == 404
@@ -1307,7 +1307,7 @@ async def test_update_shuttle_route_stop_item_internal_server_error(
         headers={"Authorization": f"Bearer {access_token}"},
         json={
             "sequence": 2,
-            "cumulativeTime": "00:10:00",
+            "cumulativeTime": -300,
         },
     )
     assert response.status_code == 500


### PR DESCRIPTION
## Changes
- 셔틀버스 정류장 정차 정보에서 기준이 되는 셔틀콕 정류소에서의 소요시간이 음의 시간이 되는 경우 (기숙사 / -00:05:00)가 있어 이를 효과적으로 생성 및 수정하기 위해 timedelta를 초로 바꿔서 사용