### PR TITLE
fix: Shuttle timetable not updated properly when weekdays is false

### DIFF
--- a/src/shuttle/service.py
+++ b/src/shuttle/service.py
@@ -476,7 +476,7 @@ async def update_timetable(
     payload: dict[str, str | int | bool | datetime.time] = {}
     if new_timetable.period_type:
         payload["period"] = new_timetable.period_type
-    if new_timetable.is_weekdays:
+    if new_timetable.is_weekdays is not None:
         payload["is_weekdays"] = new_timetable.is_weekdays
     if new_timetable.route_name:
         payload["route_name"] = new_timetable.route_name

--- a/tests/test_shuttle_routes.py
+++ b/tests/test_shuttle_routes.py
@@ -1677,6 +1677,33 @@ async def test_update_shuttle_timetable_item(
 
 
 @pytest.mark.asyncio
+async def test_update_shuttle_timetable_item_false(
+    client: TestClient,
+    clean_db,
+    create_test_user,
+    create_test_shuttle_timetable,
+):
+    access_token = await get_access_token(client)
+    response = await client.patch(
+        "/api/shuttle/timetable/1",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={
+            "period": "semester",
+            "weekdays": False,
+            "route": "test_route1",
+            "time": "00:00:00",
+        },
+    )
+    assert response.status_code == 200
+    response_json = response.json()
+    assert response_json.get("sequence") is not None
+    assert response_json.get("period") is not None
+    assert response_json.get("weekdays") is False
+    assert response_json.get("route") is not None
+    assert response_json.get("time") is not None
+
+
+@pytest.mark.asyncio
 async def test_update_shuttle_timetable_item_not_found(
     client: TestClient,
     clean_db,


### PR DESCRIPTION
## Changes
- 셔틀버스 시간표를 수정하기 위해 Patch 요청을 보낼 때, 주말 시간표를 입력하는 경우 데이터가 수정되지 않는 문제 수정